### PR TITLE
Prevent transformUrl from being called with invalid targets

### DIFF
--- a/src/hosts/azureDevops.ts
+++ b/src/hosts/azureDevops.ts
@@ -42,12 +42,12 @@ export function injectionScope(url: string) {
 			>();
 			try {
 				const label = 'Open with GitKraken';
-				const url = this.transformUrl('gkdev', 'open', pathname, search);
+				const url = this.transformUrl('open', pathname, search);
 
 				const [, , , , , type] = pathname.split('/');
 				switch (type) {
 					case 'branchCompare': {
-						const compareUrl = this.transformUrl('gkdev', 'compare', pathname, search);
+						const compareUrl = this.transformUrl('compare', pathname, search);
 						insertions.set('.bolt-header-commandbar-button-group', {
 							html: /*html*/ `<a data-gk class="gk-insert-commit bolt-header-command-item-button bolt-button" href="${compareUrl}" style="text-decoration:none !important" target="_blank" title="${label}" role="menuitem" aria-label="${label}">${this.getGitKrakenSvg(
 								20,
@@ -60,7 +60,7 @@ export function injectionScope(url: string) {
 						break;
 					}
 					case 'pullrequest': {
-						const compareUrl = this.transformUrl('gkdev', 'compare', pathname, search);
+						const compareUrl = this.transformUrl('compare', pathname, search);
 						insertions.set('.repos-pr-title-row', {
 							html: /*html*/ `<a data-gk class="gk-insert-pr bolt-header-command-item-button bolt-button" href="${url}" style="text-decoration:none !important" target="_blank" title="${label}" role="menuitem" aria-label="${label}">${this.getGitKrakenSvg(
 								20,
@@ -179,25 +179,24 @@ export function injectionScope(url: string) {
 			}
 		}
 
-		private transformUrl(
+		private transformUrl(action: 'open' | 'compare', pathname: string, search: URLSearchParams): string {
+			const redirectUrl = new URL(this.getRedirectUrl('vscode', action, pathname, search));
+			const deepLinkUrl = MODE === 'production' ? 'https://gitkraken.dev/link' : 'https://dev.gitkraken.dev/link';
+			const deepLink = new URL(`${deepLinkUrl}/${encodeURIComponent(btoa(redirectUrl.toString()))}`);
+			deepLink.searchParams.set('referrer', 'extension');
+			if (redirectUrl.searchParams.get('pr')) {
+				deepLink.searchParams.set('context', 'pr');
+			}
+			return deepLink.toString();
+		}
+
+		private getRedirectUrl(
 			target: LinkTarget,
 			action: 'open' | 'compare',
 			pathname: string,
 			search: URLSearchParams,
 		): string {
 			let { org, project, repo, type, urlTarget } = this.parsePathname(pathname);
-
-			if (target === 'gkdev') {
-				const redirectUrl = new URL(this.transformUrl('vscode', action, pathname, search));
-				const deepLinkUrl =
-					MODE === 'production' ? 'https://gitkraken.dev/link' : 'https://dev.gitkraken.dev/link';
-				const deepLink = new URL(`${deepLinkUrl}/${encodeURIComponent(btoa(redirectUrl.toString()))}`);
-				deepLink.searchParams.set('referrer', 'extension');
-				if (redirectUrl.searchParams.get('pr')) {
-					deepLink.searchParams.set('context', 'pr');
-				}
-				return deepLink.toString();
-			}
 
 			const repoId = '-';
 

--- a/src/hosts/bitbucket.ts
+++ b/src/hosts/bitbucket.ts
@@ -42,13 +42,13 @@ export function injectionScope(url: string) {
 			>();
 			try {
 				const label = 'Open with GitKraken';
-				const url = this.transformUrl('gkdev', 'open', pathname);
+				const url = this.transformUrl('open', pathname);
 
 				const [, , , type] = pathname.split('/');
 				switch (type) {
 					case 'compare': {
 						// TODO update the url when the dropdown changes/url changes
-						const compareUrl = this.transformUrl('gkdev', 'compare', pathname);
+						const compareUrl = this.transformUrl('compare', pathname);
 						insertions.set('#compare-toolbar .aui-buttons', {
 							html: /*html*/ `<a data-gk class="aui-button gk-insert-compare" style="padding-top:0px !important; padding-bottom:0px !important;" href="${compareUrl}" target="_blank" title="${label}" aria-label="${label}">${this.getGitKrakenSvg(
 								22,
@@ -63,7 +63,7 @@ export function injectionScope(url: string) {
 						break;
 					}
 					case 'pull-requests': {
-						const compareUrl = this.transformUrl('gkdev', 'compare', pathname);
+						const compareUrl = this.transformUrl('compare', pathname);
 						insertions.set('.css-1oy5iav', {
 							html: /*html*/ `<a data-gk class="gk-insert-pr css-w97uih" href="${url}" target="_blank" title="${label}" role="menuitem" aria-label="${label}">${this.getGitKrakenSvg(
 								20,
@@ -183,22 +183,21 @@ export function injectionScope(url: string) {
 			}
 		}
 
-		private transformUrl(target: LinkTarget, action: 'open' | 'compare', pathname: string): string {
+		private transformUrl(action: 'open' | 'compare', pathname: string): string {
+			const redirectUrl = new URL(this.getRedirectUrl('vscode', action, pathname));
+			const deepLinkUrl = MODE === 'production' ? 'https://gitkraken.dev/link' : 'https://dev.gitkraken.dev/link';
+			const deepLink = new URL(`${deepLinkUrl}/${encodeURIComponent(btoa(redirectUrl.toString()))}`);
+			deepLink.searchParams.set('referrer', 'extension');
+			if (redirectUrl.searchParams.get('pr')) {
+				deepLink.searchParams.set('context', 'pr');
+			}
+			return deepLink.toString();
+		}
+
+		private getRedirectUrl(target: LinkTarget, action: 'open' | 'compare', pathname: string): string {
 			let [, owner, repo, type, ...rest] = pathname.split('/');
 			if (rest?.length) {
 				rest = rest.filter(Boolean);
-			}
-
-			if (target === 'gkdev') {
-				const redirectUrl = new URL(this.transformUrl('vscode', action, pathname));
-				const deepLinkUrl =
-					MODE === 'production' ? 'https://gitkraken.dev/link' : 'https://dev.gitkraken.dev/link';
-				const deepLink = new URL(`${deepLinkUrl}/${encodeURIComponent(btoa(redirectUrl.toString()))}`);
-				deepLink.searchParams.set('referrer', 'extension');
-				if (redirectUrl.searchParams.get('pr')) {
-					deepLink.searchParams.set('context', 'pr');
-				}
-				return deepLink.toString();
 			}
 
 			const repoId = '-';

--- a/src/hosts/github.ts
+++ b/src/hosts/github.ts
@@ -69,7 +69,7 @@ export function injectionScope(url: string) {
 			const insertions = new Map<string, { html: string; position: InsertPosition }>();
 
 			const label = 'Open with GitKraken';
-			const url = this.transformUrl('gkdev', 'open');
+			const url = this.transformUrl('open');
 
 			const [, , , type] = this.uri.pathname.split('/');
 			switch (type) {
@@ -96,7 +96,7 @@ export function injectionScope(url: string) {
 
 					break;
 				case 'pull': {
-					const compareUrl = this.transformUrl('gkdev', 'compare');
+					const compareUrl = this.transformUrl('compare');
 
 					insertions.set('[data-target="get-repo.modal"] #local-panel ul li:first-child', {
 						html: /*html*/ `<li data-gk class="Box-row Box-row--hover-gray p-3 mt-0 rounded-0">
@@ -226,23 +226,22 @@ export function injectionScope(url: string) {
 			}
 		}
 
-		private transformUrl(target: LinkTarget, action: 'open' | 'compare'): string {
+		private transformUrl(action: 'open' | 'compare'): string {
+			const redirectUrl = new URL(this.getRedirectUrl('vscode', action));
+			console.debug('redirectUrl', redirectUrl);
+			const deepLinkUrl = MODE === 'production' ? 'https://gitkraken.dev/link' : 'https://dev.gitkraken.dev/link';
+			const deepLink = new URL(`${deepLinkUrl}/${encodeURIComponent(btoa(redirectUrl.toString()))}`);
+			deepLink.searchParams.set('referrer', 'extension');
+			if (redirectUrl.searchParams.get('pr')) {
+				deepLink.searchParams.set('context', 'pr');
+			}
+			return deepLink.toString();
+		}
+
+		private getRedirectUrl(target: LinkTarget, action: 'open' | 'compare'): string {
 			let [, owner, repo, type, ...rest] = this.uri.pathname.split('/');
 			if (rest?.length) {
 				rest = rest.filter(Boolean);
-			}
-
-			if (target === 'gkdev') {
-				const redirectUrl = new URL(this.transformUrl('vscode', action));
-				console.debug('redirectUrl', redirectUrl);
-				const deepLinkUrl =
-					MODE === 'production' ? 'https://gitkraken.dev/link' : 'https://dev.gitkraken.dev/link';
-				const deepLink = new URL(`${deepLinkUrl}/${encodeURIComponent(btoa(redirectUrl.toString()))}`);
-				deepLink.searchParams.set('referrer', 'extension');
-				if (redirectUrl.searchParams.get('pr')) {
-					deepLink.searchParams.set('context', 'pr');
-				}
-				return deepLink.toString();
 			}
 
 			const repoId = '-';

--- a/src/hosts/gitlab.ts
+++ b/src/hosts/gitlab.ts
@@ -23,7 +23,7 @@ export function injectionScope(url: string) {
 
 			try {
 				const label = 'Open with GitKraken';
-				const url = this.transformUrl('gkdev', 'open');
+				const url = this.transformUrl('open');
 
 				const { type, rest } = this.parseUrl(this.uri.pathname);
 
@@ -61,7 +61,7 @@ export function injectionScope(url: string) {
 							break;
 						}
 
-						const compareUrl = this.transformUrl('gkdev', 'compare');
+						const compareUrl = this.transformUrl('compare');
 
 						const container = document.querySelector<HTMLElement>(
 							'.merge-request .dropdown-menu .gl-dropdown-inner',
@@ -196,21 +196,20 @@ export function injectionScope(url: string) {
 			};
 		}
 
-		private transformUrl(target: LinkTarget, action: 'open' | 'compare'): string {
-			let { owner, repo, type, rest } = this.parseUrl(this.uri.pathname);
-
-			if (target === 'gkdev') {
-				const redirectUrl = new URL(this.transformUrl('vscode', action));
-				console.debug('redirectUrl', redirectUrl);
-				const deepLinkUrl =
-					MODE === 'production' ? 'https://gitkraken.dev/link' : 'https://dev.gitkraken.dev/link';
-				const deepLink = new URL(`${deepLinkUrl}/${encodeURIComponent(btoa(redirectUrl.toString()))}`);
-				deepLink.searchParams.set('referrer', 'extension');
-				if (redirectUrl.searchParams.get('pr')) {
-					deepLink.searchParams.set('context', 'pr');
-				}
-				return deepLink.toString();
+		private transformUrl(action: 'open' | 'compare'): string {
+			const redirectUrl = new URL(this.getRedirectUrl('vscode', action));
+			console.debug('redirectUrl', redirectUrl);
+			const deepLinkUrl = MODE === 'production' ? 'https://gitkraken.dev/link' : 'https://dev.gitkraken.dev/link';
+			const deepLink = new URL(`${deepLinkUrl}/${encodeURIComponent(btoa(redirectUrl.toString()))}`);
+			deepLink.searchParams.set('referrer', 'extension');
+			if (redirectUrl.searchParams.get('pr')) {
+				deepLink.searchParams.set('context', 'pr');
 			}
+			return deepLink.toString();
+		}
+
+		private getRedirectUrl(target: LinkTarget, action: 'open' | 'compare'): string {
+			let { owner, repo, type, rest } = this.parseUrl(this.uri.pathname);
 
 			const repoId = '-';
 

--- a/src/provider.ts
+++ b/src/provider.ts
@@ -1,4 +1,4 @@
-export type LinkTarget = 'gitkraken' | 'gkdev' | 'vscode' | 'vscode-insiders' | 'client';
+export type LinkTarget = 'vscode' | 'vscode-insiders';
 
 export interface InjectionProvider {
 	inject(): void;


### PR DESCRIPTION
Opening this for review to confirm if some assumptions I've made are actually correct:

1. The redirect url form is always in the form of `${target}://eamodio.gitlens/`, meaning the only link targets that are actually valid are the vscode ones, not everything that used to be listed in `LinkTarget`
2. The extension will always link to gk.dev, not any other target, so `transformUrl` should always use `gkdev` as the "target"