### PR TITLE
GKCS-5303 Allow the browser extension to connect to On-premise GitHub environments

### DIFF
--- a/scripts/makeManifest.js
+++ b/scripts/makeManifest.js
@@ -18,7 +18,7 @@ const manifestBase = {
 		48: 'icons/gk-grey-48.png',
 		128: 'icons/gk-grey-128.png',
 	},
-	permissions: ['cookies', 'scripting', 'webNavigation'],
+	permissions: ['cookies', 'scripting', 'storage', 'webNavigation'],
 	host_permissions: [
 		'*://*.github.com/*',
 		'*://*.gitlab.com/*',
@@ -41,7 +41,7 @@ const getMakeManifest =
 			browser_specific_settings: {
 				gecko: {
 					id: 'gitkraken-browser@gitkraken.com',
-					strict_min_version: '109.0',
+					strict_min_version: '115.0',
 				},
 			},
 			// Delete this in favor of optional_host_permissions when https://bugzilla.mozilla.org/show_bug.cgi?id=1766026
@@ -52,6 +52,7 @@ const getMakeManifest =
 		};
 
 		const chromiumKeys = {
+			minimum_chrome_version: "102",
 			background: {
 				service_worker: 'dist/service-worker.js',
 			},

--- a/scripts/makeManifest.js
+++ b/scripts/makeManifest.js
@@ -18,7 +18,7 @@ const manifestBase = {
 		48: 'icons/gk-grey-48.png',
 		128: 'icons/gk-grey-128.png',
 	},
-	permissions: ['cookies', 'scripting', 'storage', 'webNavigation'],
+	permissions: ['cookies', 'scripting', 'webNavigation'],
 	host_permissions: [
 		'*://*.github.com/*',
 		'*://*.gitlab.com/*',
@@ -41,7 +41,7 @@ const getMakeManifest =
 			browser_specific_settings: {
 				gecko: {
 					id: 'gitkraken-browser@gitkraken.com',
-					strict_min_version: '115.0',
+					strict_min_version: '109.0',
 				},
 			},
 			// Delete this in favor of optional_host_permissions when https://bugzilla.mozilla.org/show_bug.cgi?id=1766026
@@ -52,7 +52,6 @@ const getMakeManifest =
 		};
 
 		const chromiumKeys = {
-			minimum_chrome_version: "102",
 			background: {
 				service_worker: 'dist/service-worker.js',
 			},

--- a/src/background.ts
+++ b/src/background.ts
@@ -6,16 +6,23 @@ import { injectionScope as inject_bitbucket } from './hosts/bitbucket';
 import { injectionScope as inject_github } from './hosts/github';
 import { injectionScope as inject_gitlab } from './hosts/gitlab';
 import { refreshPermissions } from './permissions-helper';
-import { PopupInitMessage } from './shared';
+import { getEnterpriseConnections, getKeyFromStorage, InjectionDomainsStorageKey, PopupInitMessage, setKeyToStorage } from './shared';
+import type { CacheContext } from './types';
+import { Provider } from './types';
 
-webNavigation.onDOMContentLoaded.addListener(injectScript, {
-	url: [
-		{ hostContains: 'github.com' },
-		{ hostContains: 'gitlab.com' },
-		{ hostContains: 'bitbucket.org' },
-		{ hostContains: 'dev.azure.com' },
-	],
-});
+interface InjectionDomains {
+	github: string[];
+	gitlab: string[];
+	bitbucket: string[];
+	azureDevops: string[];
+}
+
+const DefaultInjectionDomains: InjectionDomains = {
+	github: ['github.com'],
+	gitlab: ['gitlab.com'],
+	bitbucket: ['bitbucket.org'],
+	azureDevops: ['dev.azure.com']
+};
 
 webNavigation.onHistoryStateUpdated.addListener(details => {
 	// used to detect when the user navigates to a different page in the same tab
@@ -30,36 +37,85 @@ webNavigation.onHistoryStateUpdated.addListener(details => {
 
 runtime.onMessage.addListener(async (msg) => {
 	if (msg === PopupInitMessage) {
-		return refreshPermissions();
+		const context: CacheContext = {};
+		const injectionDomains = await computeInjectionDomains(context);
+		await storeInjectionDomains(injectionDomains);
+		// NOTE: This may request hosts that we may not have permissions for, which will log errors for the extension
+		// This does not cause any issues, and eliminating the errors requires more logic
+		addInjectionListener(injectionDomains);
+		return refreshPermissions(context);
 	}
 	console.error('Recevied unknown runtime message', msg);
 	return undefined;
 });
 
-function injectScript(details: WebNavigation.OnDOMContentLoadedDetailsType) {
+async function retrieveInjectionDomains() {
+	return await getKeyFromStorage(InjectionDomainsStorageKey) as InjectionDomains | undefined;
+}
+
+async function storeInjectionDomains(injectionDomains: InjectionDomains) {
+	await setKeyToStorage(InjectionDomainsStorageKey, injectionDomains);
+}
+
+async function computeInjectionDomains(context: CacheContext) {
+	const injectionDomains = structuredClone(DefaultInjectionDomains);
+	const enterpriseConnections = await getEnterpriseConnections(context);
+	if (enterpriseConnections) {
+		for (const connection of enterpriseConnections) {
+			if (connection.provider === Provider.GITHUB_ENTERPRISE) {
+				injectionDomains.github.push(connection.domain);
+			}
+		}
+	}
+	return injectionDomains;
+}
+
+function addInjectionListener(injectionDomains: InjectionDomains) {
+	// NOTE: The listener has to be a static reference so that we can re-add the listener at any point
+	if (webNavigation.onDOMContentLoaded.hasListener(injectScript)) {
+		webNavigation.onDOMContentLoaded.removeListener(injectScript);
+	} else {
+		console.debug('Adding onDOMContentLoaded injection listener for the first time');
+	}
+	const allDomains = Object.values<string[]>(injectionDomains as any).flat();
+	webNavigation.onDOMContentLoaded.addListener(injectScript, {
+		url: allDomains.map((domain) => ({ hostContains: domain })),
+	});
+}
+
+async function injectScript(details: WebNavigation.OnDOMContentLoadedDetailsType) {
+	const injectionDomains = await retrieveInjectionDomains();
+	if (!injectionDomains) {
+		console.error('Could not find injection domains in storage');
+		return;
+	}
 	void scripting.executeScript({
 		target: { tabId: details.tabId },
 		// injectImmediately: true,
-		func: getInjectionFn(details.url),
+		func: getInjectionFn(details.url, injectionDomains),
 		args: [details.url],
 	});
 }
 
-function getInjectionFn(url: string): (url: string) => void {
-	const uri = new URL(url);
-	if (uri.hostname.endsWith('github.com')) {
+function urlHostHasDomain(url: URL, domains: string[]): boolean {
+	return domains.some((domain) => url.hostname.endsWith(domain));
+}
+
+function getInjectionFn(rawUrl: string, injectionDomains: InjectionDomains): (url: string) => void {
+	const url = new URL(rawUrl);
+	if (urlHostHasDomain(url, injectionDomains.github)) {
 		return inject_github;
 	}
 
-	if (uri.hostname.endsWith('gitlab.com')) {
+	if (urlHostHasDomain(url, injectionDomains.gitlab)) {
 		return inject_gitlab;
 	}
 
-	if (uri.hostname.endsWith('bitbucket.org')) {
+	if (urlHostHasDomain(url, injectionDomains.bitbucket)) {
 		return inject_bitbucket;
 	}
 
-	if (uri.hostname.endsWith('dev.azure.com')) {
+	if (urlHostHasDomain(url, injectionDomains.azureDevops)) {
 		return inject_azureDevops;
 	}
 
@@ -67,12 +123,18 @@ function getInjectionFn(url: string): (url: string) => void {
 	throw new Error('Unsupported host');
 }
 
-const main = async () => {
+async function main() {
 	// The fetchUser function also updates the extension icon if the user is logged in
 	await fetchUser();
 
+	const context: CacheContext = {};
 	// This removes unneded permissions
-	await refreshPermissions();
+	await refreshPermissions(context);
+	const injectionDomains = await computeInjectionDomains(context);
+	await storeInjectionDomains(injectionDomains);
+	// NOTE: This may request hosts that we may not have permissions for, which will log errors for the extension
+	// This does not cause any issues, and eliminating the errors requires more logic
+	addInjectionListener(injectionDomains);
 };
 
 void main();

--- a/src/gkApi.ts
+++ b/src/gkApi.ts
@@ -1,7 +1,7 @@
 import { cookies } from 'webextension-polyfill';
 import { checkOrigins } from './permissions-helper';
 import { updateExtensionIcon } from './shared';
-import type { User } from './types';
+import type { ProviderConnection, User } from './types';
 
 declare const MODE: 'production' | 'development' | 'none';
 
@@ -71,4 +71,24 @@ export const logoutUser = async () => {
 	});
 
 	await updateExtensionIcon(false);
+};
+
+export const getProviderConnections = async (): Promise<ProviderConnection[] | null> => {
+	const token = await getAccessToken();
+	if (!token) {
+		return null;
+	}
+
+	const res = await fetch(`${gkApiUrl}/v1/provider-tokens/`, {
+		headers: {
+			Authorization: `Bearer ${token}`,
+		},
+	});
+
+	if (!res.ok) {
+		return null;
+	}
+
+	const payload = await res.json();
+	return payload.data as ProviderConnection[];
 };

--- a/src/hosts/github.ts
+++ b/src/hosts/github.ts
@@ -134,6 +134,17 @@ export function injectionScope(url: string) {
 				}
 				case 'tree':
 				case undefined:
+					// Enterpise v3.11.2
+					insertions.set('[data-target="get-repo.modal"] ul li:last-child', {
+						html: /*html*/ `<li data-gk class="Box-row Box-row--hover-gray p-3 mt-0 rounded-0">
+	<a class="d-flex flex-items-center color-fg-default text-bold no-underline" href="${url}" target="_blank" title="${label}" aria-label="${label}">
+		${this.getGitKrakenSvg(16, 'mr-2')}
+		${label}
+	</a>
+</li>`,
+						position: 'afterend',
+					});
+
 					insertions.set('[data-target="get-repo.modal"] #local-panel ul li:first-child', {
 						html: /*html*/ `<li data-gk class="Box-row Box-row--hover-gray p-3 mt-0 rounded-0">
 	<a class="d-flex flex-items-center color-fg-default text-bold no-underline" href="${url}" target="_blank" title="${label}" aria-label="${label}">

--- a/src/popup.ts
+++ b/src/popup.ts
@@ -174,7 +174,15 @@ const renderPermissionRequest = (permissionsRequest: PermissionsRequest) => {
 		supportLink.classList.add('menu-row');
 		mainEl.append(supportLink);
 	} else {
-		permissionRequestLink.append(createFAIcon('fa-triangle-exclamation'), `Allow permissions for cloud git providers`);
+		const typesRequested: string[] = [];
+		if (permissionsRequest.hasCloud) {
+			typesRequested.push('cloud');
+		}
+		if (permissionsRequest.hasEnterprise) {
+			typesRequested.push('self-hosted');
+		}
+
+		permissionRequestLink.append(createFAIcon('fa-triangle-exclamation'), `Allow permissions for ${typesRequested.join(' & ')} git providers`);
 		mainEl.append(permissionRequestLink);
 	}
 };

--- a/src/popup.ts
+++ b/src/popup.ts
@@ -4,7 +4,7 @@ import { permissions, runtime } from 'webextension-polyfill';
 import { createAnchor, createFAIcon } from './domUtils';
 import { fetchUser, logoutUser } from './gkApi';
 import type { PermissionsRequest } from './permissions-helper';
-import { PopupInitMessage } from './shared';
+import { PermissionsGrantedMessage, PopupInitMessage } from './shared';
 import type { User } from './types';
 
 declare const MODE: 'production' | 'development' | 'none';
@@ -149,17 +149,18 @@ const syncWithBackground = async () => {
 	return await runtime.sendMessage(PopupInitMessage) as PermissionsRequest | undefined;
 };
 
-function reloadPopup() {
-	// This seems to work on Firefox and Chromium but I couldn't find any docs confirming this is the correct way
-	window.location.reload();
-}
+const sendPermissionsGranted = async () => {
+	await runtime.sendMessage(PermissionsGrantedMessage);
+};
 
 const renderPermissionRequest = (permissionsRequest: PermissionsRequest) => {
 	const mainEl = document.getElementById('main-content')!;
 
 	const permissionRequestLink = createAnchor('#', undefined, async () => {
-		await permissions.request(permissionsRequest.request);
-		reloadPopup();
+		const granted = await permissions.request(permissionsRequest.request);
+		if (granted) {
+			await sendPermissionsGranted();
+		}
 	});
 	permissionRequestLink.classList.add('alert');
 	if (permissionsRequest.hasRequired) {

--- a/src/shared.ts
+++ b/src/shared.ts
@@ -1,6 +1,10 @@
-import { action } from 'webextension-polyfill';
+import { action, storage } from 'webextension-polyfill';
+import { getProviderConnections } from './gkApi';
+import type { CacheContext, EnterpriseProviderConnection, ProviderConnection } from './types';
+import { Provider } from './types';
 
 export const PopupInitMessage = 'popupInit';
+export const InjectionDomainsStorageKey = 'injectionDomains';
 
 const IconPaths = {
 	Grey: {
@@ -37,3 +41,57 @@ export function arrayDifference<T>(first: T[] | undefined, second: T[] | undefin
 	}
 	return first.filter(x => !second.includes(x));
 }
+
+function ensureDomain(value: string): string {
+	// Check if value is a URL or actually a domain
+	try {
+		const url = new URL(value);
+		return url.hostname;
+	} catch (e) {
+		// Not a valid URL, so it's probably a domain
+		if (!(e instanceof TypeError)) {
+			console.error('Unexpected error constructing URL', e);
+		}
+	}
+	return value;
+}
+
+async function cacheOnContext<K extends keyof CacheContext>(cache: CacheContext, key: K, fn: () => Promise<CacheContext[K] | undefined>): ReturnType<typeof fn> {
+	if (cache[key]) {
+		return cache[key];
+	}
+	const result = await fn();
+	if (result !== undefined) {
+		cache[key] = result;
+	}
+	return result;
+}
+
+function isEnterpriseProviderConnection(connection: ProviderConnection): connection is EnterpriseProviderConnection {
+	return Boolean((connection.provider === Provider.GITHUB_ENTERPRISE) && connection.domain);
+}
+
+export async function getEnterpriseConnections(context: CacheContext) {
+	return cacheOnContext(context, 'enterpriseConnectionsCache', async () => {
+		const providerConnections = await getProviderConnections();
+		if (!providerConnections) {
+			return;
+		}
+		// note: GitLab support comes later
+		const enterpriseConnections = providerConnections
+			.filter(isEnterpriseProviderConnection)
+			.map(
+				// typing is weird here, but we need to ensure domain is actually a domain
+				(connection: EnterpriseProviderConnection): EnterpriseProviderConnection => ({ ...connection, domain: ensureDomain(connection.domain) })
+			);
+		return enterpriseConnections;
+	});
+}
+
+export async function getKeyFromStorage(key: string): Promise<unknown> {
+	return (await storage.session.get(key))[key] as unknown;
+}
+
+export async function setKeyToStorage(key: string, value: unknown) {
+	return storage.session.set({ [key]: value });
+};

--- a/src/shared.ts
+++ b/src/shared.ts
@@ -1,10 +1,10 @@
-import { action, storage } from 'webextension-polyfill';
+import { action } from 'webextension-polyfill';
 import { getProviderConnections } from './gkApi';
 import type { CacheContext, EnterpriseProviderConnection, ProviderConnection } from './types';
 import { Provider } from './types';
 
 export const PopupInitMessage = 'popupInit';
-export const InjectionDomainsStorageKey = 'injectionDomains';
+export const PermissionsGrantedMessage = 'permissionsGranted';
 
 const IconPaths = {
 	Grey: {
@@ -87,11 +87,3 @@ export async function getEnterpriseConnections(context: CacheContext) {
 		return enterpriseConnections;
 	});
 }
-
-export async function getKeyFromStorage(key: string): Promise<unknown> {
-	return (await storage.session.get(key))[key] as unknown;
-}
-
-export async function setKeyToStorage(key: string, value: unknown) {
-	return storage.session.set({ [key]: value });
-};

--- a/src/types.ts
+++ b/src/types.ts
@@ -8,3 +8,20 @@ export interface User {
 	};
 	username: string;
 }
+
+export enum Provider {
+	GITHUB_ENTERPRISE = 'githubEnterprise',
+}
+
+export interface ProviderConnection {
+	provider: Provider;
+	type: string;
+	domain?: string; // NOTE: This could include the protocol scheme
+}
+
+// NOTE: domain here is actually a domain name, not a URI
+export type EnterpriseProviderConnection = ProviderConnection & Required<Pick<ProviderConnection, 'domain'>>;
+
+export interface CacheContext {
+	enterpriseConnectionsCache?: EnterpriseProviderConnection[];
+}

--- a/static/popup.css
+++ b/static/popup.css
@@ -16,7 +16,7 @@
 
 /* Popup container */
 #main-content {
-	width: 287px;
+	min-width: 287px;
 	padding: 8px;
 	font-size: var(--text-md);
 }
@@ -50,6 +50,7 @@ button.menu-row {
 	display: flex;
 	align-items: center;
 	padding: 8px;
+	white-space: nowrap;
 }
 a.alert {
 	text-decoration: none;


### PR DESCRIPTION
https://gitkraken.atlassian.net/browse/GKCS-5303

Tested with https://ghe.ci.gitkraken.com (running Enterprise v3.11.2).

There are buttons on commit comparison, individual commits, and repo landing pages. (i.e. `< > Code` tab of a repo).

However for PRs, I noticed there's no `< > Code` button, so I didn't add any buttons on PR pages (note: this might be because our instance is behaving weirdly right now: https://gitkraken-hq.slack.com/archives/C05BYV78VQB/p1709170626154339)