### PR TITLE
GKCS-5304 Allow the browser extension to connect to On-prem GitLab

### DIFF
--- a/src/background.ts
+++ b/src/background.ts
@@ -56,6 +56,9 @@ async function computeInjectionDomains(context: CacheContext) {
 			if (connection.provider === Provider.GITHUB_ENTERPRISE) {
 				injectionDomains.github.push(connection.domain);
 			}
+			if (connection.provider === Provider.GITLAB_SELF_HOSTED) {
+				injectionDomains.gitlab.push(connection.domain);
+			}
 		}
 	}
 	return injectionDomains;

--- a/src/hosts/gitlab.ts
+++ b/src/hosts/gitlab.ts
@@ -14,6 +14,12 @@ export function injectionScope(url: string) {
 		}
 
 		private render() {
+			// Remove all previous injected elements
+			const els = document.querySelectorAll('[data-gk]');
+			for (const el of els) {
+				el.remove();
+			}
+
 			const insertions = this.getInsertions();
 			this.insertHTML(insertions);
 		}
@@ -129,6 +135,24 @@ export function injectionScope(url: string) {
 			</a>
 		</li>
 	</ul>
+</li>`,
+								position: 'afterend',
+							},
+						);
+
+						// v16.8
+						insertions.set(
+							'.git-clone-holder .dropdown-menu .gl-dropdown-item:last-child',
+							{
+								html: /*html*/ `<li data-gk class="divider mt-2" role="presentation"></li>
+<li data-gk class="gl-dropdown-item pt-2" role="menuitem">
+	<label class="label-bold gl-px-4">GitKraken</label>
+	<a class="dropdown-item open-with-link" href="${url}" style="align-items: center !important;" target="_blank">
+		<div class="gl-dropdown-item-text-wrapper" style="display: flex; align-items: center !important;">
+			${this.getGitKrakenSvg(16, 'mr-2 gl-icon', 'flex: 0 0 auto;')}
+			<span>${label}</span>
+		</div>
+	</a>
 </li>`,
 								position: 'afterend',
 							},

--- a/src/shared.ts
+++ b/src/shared.ts
@@ -68,7 +68,7 @@ async function cacheOnContext<K extends keyof CacheContext>(cache: CacheContext,
 }
 
 function isEnterpriseProviderConnection(connection: ProviderConnection): connection is EnterpriseProviderConnection {
-	return Boolean((connection.provider === Provider.GITHUB_ENTERPRISE) && connection.domain);
+	return Boolean(([Provider.GITHUB_ENTERPRISE, Provider.GITLAB_SELF_HOSTED].includes(connection.provider)) && connection.domain);
 }
 
 export async function getEnterpriseConnections(context: CacheContext) {

--- a/src/types.ts
+++ b/src/types.ts
@@ -11,6 +11,7 @@ export interface User {
 
 export enum Provider {
 	GITHUB_ENTERPRISE = 'githubEnterprise',
+	GITLAB_SELF_HOSTED = 'gitlabSelfHosted',
 }
 
 export interface ProviderConnection {


### PR DESCRIPTION
https://gitkraken.atlassian.net/browse/GKCS-5304

All existing buttons are working, except a new injection is needed for the repo home page on v16.8:

![image](https://github.com/gitkraken/gk-browser-extension/assets/102260814/6d6e519c-f569-46e2-98c8-81f3c09fbdee)
