### PR TITLE
Show support link when signed-in

### DIFF
--- a/src/popup.ts
+++ b/src/popup.ts
@@ -98,6 +98,14 @@ const renderLoggedInContent = async (user: User) => {
 
 	mainEl.append(userEl);
 
+	const supportLink = createAnchor(
+		'https://help.gitkraken.com/browser-extension/gitkraken-browser-extension',
+		'_blank',
+	);
+	supportLink.append(createFAIcon('fa-question-circle'), 'Support');
+	supportLink.classList.add('menu-row');
+	mainEl.append(supportLink);
+
 	/* Sign out button */
 	const signOutBtn = document.createElement('button');
 	signOutBtn.append(createFAIcon('fa-right-from-bracket'), 'Sign out');


### PR DESCRIPTION
https://gitkraken.atlassian.net/browse/GKCS-5380

Jeff mentioned that he'd like a support link above the Sign Out button when signed-in

![image](https://github.com/gitkraken/gk-browser-extension/assets/102260814/f0116da8-b48c-48b5-a04b-a9bb83306cea)
