### PR TITLE
Refresh provider token if it is expired

### DIFF
--- a/src/popup/components/FocusView.tsx
+++ b/src/popup/components/FocusView.tsx
@@ -152,6 +152,7 @@ export const FocusView = () => {
 			}
 
 			if (!focusViewData) {
+				setPullRequestBuckets([]);
 				setIsLoadingPullRequests(false);
 				setIsFirstLoad(false);
 				return;


### PR DESCRIPTION
GitLab, Bitbucket, and Azure stop working after a few hours since their tokens need to be refreshed. This is similar to what gk.dev does.