### PR TITLE
Add "Open with GitKraken" link to Focus View PRs

### DIFF
--- a/src/deepLink.ts
+++ b/src/deepLink.ts
@@ -1,0 +1,240 @@
+import type { LinkTarget } from './provider';
+import { GKDotDevUrl } from './shared';
+import type { FocusViewSupportedProvider } from './types';
+
+const getGKDotDevLinkUrl = (redirectUrlString: string) => {
+	const redirectUrl = new URL(redirectUrlString);
+	const deepLinkUrl = `${GKDotDevUrl}/link`;
+	const deepLink = new URL(`${deepLinkUrl}/${encodeURIComponent(btoa(redirectUrl.toString()))}`);
+	deepLink.searchParams.set('referrer', 'extension');
+	if (redirectUrl.searchParams.get('pr')) {
+		deepLink.searchParams.set('context', 'pr');
+	}
+
+	return deepLink.toString();
+};
+
+const getGitHubRedirectUrl = (url: string, target: LinkTarget) => {
+	const uri = new URL(url);
+	let [, owner, repo, type, ...rest] = uri.pathname.split('/');
+	if (rest?.length) {
+		rest = rest.filter(Boolean);
+	}
+
+	const repoId = '-';
+
+	let redirectUrl: URL | null = null;
+	switch (type) {
+		case 'pull': {
+			const [prNumber] = rest;
+			redirectUrl = new URL(`${target}://eamodio.gitlens/link/r/${repoId}`);
+			redirectUrl.searchParams.set('pr', prNumber);
+			redirectUrl.searchParams.set('prUrl', uri.toString());
+			break;
+		}
+		default:
+			redirectUrl = new URL(`${target}://eamodio.gitlens/link/r/${repoId}`);
+			break;
+	}
+
+	const remoteUrl = new URL(uri.toString());
+	remoteUrl.hash = '';
+	remoteUrl.search = '';
+	remoteUrl.pathname = `/${owner}/${repo}.git`;
+
+	redirectUrl.searchParams.set('url', remoteUrl.toString());
+	return redirectUrl.toString();
+};
+
+const parseGitLabUrl = (
+	rawUrl: string,
+): {
+	owner: string;
+	subgroups: string[];
+	repo: string;
+	type: string | undefined;
+	rest: string[];
+} => {
+	// remove slash at the end of the pathname
+	const path = rawUrl.endsWith('/') ? rawUrl.substring(0, rawUrl.length - 1) : rawUrl;
+
+	const split = path.split('/');
+	const separatorIndex = split.findIndex(value => value == '-');
+
+	// if we couldn't find a separator index, assume that we're on the front page of a repository
+	if (separatorIndex === -1) {
+		return {
+			owner: split[1],
+			subgroups: split.slice(2, split.length - 1),
+			repo: split[split.length - 1],
+			type: undefined,
+			rest: [],
+		};
+	}
+
+	return {
+		owner: split[1],
+		subgroups: split.slice(2, separatorIndex - 1),
+		repo: split[separatorIndex - 1],
+		type: split.at(separatorIndex + 1),
+		rest: separatorIndex + 2 < split.length ? split.slice(separatorIndex + 2, split.length) : [],
+	};
+};
+
+const getGitLabRedirectUrl = (url: string, target: LinkTarget) => {
+	const uri = new URL(url);
+	const { owner, repo, type, rest } = parseGitLabUrl(uri.pathname);
+
+	const repoId = '-';
+
+	let redirectUrl: URL | null = null;
+	switch (type) {
+		case 'merge_requests': {
+			const [prNumber] = rest;
+			redirectUrl = new URL(`${target}://eamodio.gitlens/link/r/${repoId}`);
+			redirectUrl.searchParams.set('pr', prNumber);
+			redirectUrl.searchParams.set('prUrl', uri.toString());
+			break;
+		}
+		default: {
+			redirectUrl = new URL(`${target}://eamodio.gitlens/link/r/${repoId}`);
+			break;
+		}
+	}
+
+	const remoteUrl = new URL(uri.toString());
+	remoteUrl.hash = '';
+	remoteUrl.search = '';
+	remoteUrl.pathname = `/${owner}/${repo}.git`;
+
+	redirectUrl.searchParams.set('url', remoteUrl.toString());
+	return redirectUrl.toString();
+};
+
+const getBitbucketRedirectUrl = (url: string, target: LinkTarget) => {
+	const uri = new URL(url);
+	let [, owner, repo, type, ...rest] = uri.pathname.split('/');
+	if (rest?.length) {
+		rest = rest.filter(Boolean);
+	}
+
+	const repoId = '-';
+
+	let redirectUrl: URL | null = null;
+	switch (type) {
+		case 'pull-requests': {
+			const [prNumber] = rest;
+			redirectUrl = new URL(`${target}://eamodio.gitlens/link/r/${repoId}`);
+			redirectUrl.searchParams.set('pr', prNumber);
+			redirectUrl.searchParams.set('prUrl', uri.toString());
+			break;
+		}
+		default:
+			redirectUrl = new URL(`${target}://eamodio.gitlens/link/r/${repoId}`);
+			break;
+	}
+
+	const remoteUrl = new URL(uri.toString());
+	remoteUrl.hash = '';
+	remoteUrl.search = '';
+	remoteUrl.pathname = `/${owner}/${repo}.git`;
+
+	redirectUrl.searchParams.set('url', remoteUrl.toString());
+	return redirectUrl.toString();
+};
+
+const parseAzurePathname = (
+	pathname: string,
+): {
+	org: string;
+	project: string;
+	repo: string;
+	type: string | undefined;
+	urlTarget: string;
+} => {
+	// the default repo of a project has the same name and has a url that is formatted
+	// slightly differently than a repo that doesn't share the same name as the project
+	let project = '';
+	let repo = '';
+	let type = '';
+	let urlTarget = '';
+
+	const [, org, ...rest] = pathname.split('/');
+	if (rest[0] === '_git') {
+		[, project, type, urlTarget] = rest;
+		repo = project;
+	} else {
+		[project, , repo, type, urlTarget] = rest;
+	}
+
+	return { org: org, project: project, repo: repo, type: type, urlTarget: urlTarget };
+};
+
+const getAzureRedirectUrl = (url: string, target: LinkTarget) => {
+	const uri = new URL(url);
+	const { pathname, searchParams: search } = uri;
+	const { org, project, repo, type, urlTarget } = parseAzurePathname(pathname);
+
+	const repoId = '-';
+
+	let redirectUrl: URL | null = null;
+	switch (type) {
+		case 'pullrequest': {
+			const prNumber = urlTarget;
+			redirectUrl = new URL(`${target}://eamodio.gitlens/link/r/${repoId}`);
+			redirectUrl.searchParams.set('pr', prNumber);
+			redirectUrl.searchParams.set('prUrl', uri.toString());
+			break;
+		}
+		default: {
+			const branch = search.get('version')?.slice(2);
+			if (branch) {
+				redirectUrl = new URL(`${target}://eamodio.gitlens/link/r/${repoId}/b/${branch}`);
+			} else {
+				redirectUrl = new URL(`${target}://eamodio.gitlens/link/r/${repoId}`);
+			}
+			break;
+		}
+	}
+
+	const remoteUrl = `https://${org}@dev.azure.com/${org}/${project}/_git/${repo}`;
+	redirectUrl.searchParams.set('url', remoteUrl.toString());
+	return redirectUrl.toString();
+};
+
+export const getGitKrakenDeepLinkUrl = (provider: FocusViewSupportedProvider, url: string | null) => {
+	if (!url) {
+		return null;
+	}
+
+	let redirectUrl = '';
+	switch (provider) {
+		case 'github':
+			redirectUrl = getGitHubRedirectUrl(url, 'vscode');
+			break;
+		case 'gitlab':
+			redirectUrl = getGitLabRedirectUrl(url, 'vscode');
+			break;
+		case 'bitbucket':
+			redirectUrl = getBitbucketRedirectUrl(url, 'vscode');
+			break;
+		case 'azure':
+			redirectUrl = getAzureRedirectUrl(url, 'vscode');
+			break;
+	}
+
+	if (!redirectUrl) {
+		return null;
+	}
+
+	return getGKDotDevLinkUrl(redirectUrl);
+};
+
+export const openGitKrakenDeepLink = (provider: FocusViewSupportedProvider, url: string | null) => {
+	const deepLink = getGitKrakenDeepLinkUrl(provider, url);
+	if (!deepLink) {
+		return;
+	}
+
+	window.open(deepLink, '_blank');
+};

--- a/src/hosts/github.ts
+++ b/src/hosts/github.ts
@@ -253,7 +253,6 @@ export function injectionScope(url: string, gkDotDevUrl: string) {
 		private transformUrl(action: 'open' | 'compare'): string {
 			const redirectUrl = new URL(this.getRedirectUrl('vscode', action));
 			console.debug('redirectUrl', redirectUrl);
-			console.log('GKDotDevUrl', gkDotDevUrl);
 			const deepLinkUrl = `${gkDotDevUrl}/link`;
 			const deepLink = new URL(`${deepLinkUrl}/${encodeURIComponent(btoa(redirectUrl.toString()))}`);
 			deepLink.searchParams.set('referrer', 'extension');

--- a/src/popup/components/FocusView.tsx
+++ b/src/popup/components/FocusView.tsx
@@ -2,6 +2,7 @@ import type { PullRequestBucket } from '@gitkraken/provider-apis';
 import { GitProviderUtils } from '@gitkraken/provider-apis';
 import React, { useEffect, useState } from 'react';
 import { storage } from 'webextension-polyfill';
+import { openGitKrakenDeepLink } from '../../deepLink';
 import { fetchDraftCounts, fetchProviderConnections } from '../../gkApi';
 import { fetchFocusViewData, ProviderMeta } from '../../providers';
 import { DefaultCacheTimeMinutes, GKDotDevUrl, sessionCachedFetch } from '../../shared';
@@ -25,23 +26,31 @@ const PullRequestRow = ({ pullRequest, provider, draftCount = 0 }: PullRequestRo
 			<div className="pull-request">
 				<div className="pull-request-title truncate">{pullRequest.title}</div>
 				<div className="repository-name text-secondary truncate">{pullRequest.repository.name}</div>
-				<a
-					className="pull-request-number text-link"
-					href={pullRequest.url || undefined}
-					target="_blank"
-					onClick={() => {
-						// Since there is a decent chance that the PR will be acted upon after the user clicks on it,
-						// invalidate the cache so that the PR shows up in the appropriate bucket (or not at all) the
-						// next time the popup is opened.
-						void storage.session.remove('focusViewData');
-					}}
-					title={`View pull request on ${ProviderMeta[provider].name}`}
-				>
-					#{pullRequest.number}
-				</a>
-				{/* <a>
-				<i className="fa-brands fa-gitkraken icon text-link" />
-			</a> */}
+				<div className="pull-request-number">
+					<a
+						className="text-link"
+						href={pullRequest.url || undefined}
+						target="_blank"
+						onClick={() => {
+							// Since there is a decent chance that the PR will be acted upon after the user clicks on it,
+							// invalidate the cache so that the PR shows up in the appropriate bucket (or not at all) the
+							// next time the popup is opened.
+							void storage.session.remove('focusViewData');
+						}}
+						title={`View pull request on ${ProviderMeta[provider].name}`}
+					>
+						#{pullRequest.number}
+					</a>
+				</div>
+				{pullRequest.url && (
+					<a
+						href="#"
+						onClick={() => openGitKrakenDeepLink(provider, pullRequest.url)}
+						title="Open with GitKraken"
+					>
+						<i className="fa-brands fa-gitkraken icon text-link text-lg" />
+					</a>
+				)}
 			</div>
 			{draftCount > 0 && (
 				<a

--- a/static/popup.css
+++ b/static/popup.css
@@ -245,7 +245,7 @@ html {
 	margin-right: 12px;
 }
 .focus-view .pull-request-bucket .pull-request .pull-request-title {
-	width: 300;
+	width: 274;
 }
 .focus-view .pull-request-bucket .pull-request .repository-name {
 	width: 148px;


### PR DESCRIPTION
Attempts to share code with the injection hosts turned out to be more complicated than I realized when I discovered that literally only the contents of `injectionScope` get injected and anything outside of it (such as imports) do not. Instead, I just ended up writing a "light" version of the existing `getRedirectUrl` functions that just handle PRs and don't check for things in DOM.