### PR TITLE
Call check-in route when popup is opened

### DIFF
--- a/src/gkApi.ts
+++ b/src/gkApi.ts
@@ -41,6 +41,30 @@ export const getAccessToken = async () => {
 	return cookie?.value;
 };
 
+export const checkin = async () => {
+	const token = await getAccessToken();
+	if (!token) {
+		return;
+	}
+
+	// Don't check in more than once every 12 hours to reduce amount of requests
+	const { lastCheckin } = await storage.local.get('lastCheckin');
+	if (lastCheckin && Date.now() - lastCheckin < 1000 * 60 * 60) {
+		return;
+	}
+
+	const res = await fetch(`${gkApiUrl}/browser-extension/checkin`, {
+		headers: {
+			Authorization: `Bearer ${token}`,
+		},
+		method: 'POST',
+	});
+
+	if (res.ok) {
+		void storage.local.set({ lastCheckin: Date.now() });
+	}
+};
+
 export const fetchUser = async () => {
 	const token = await getAccessToken();
 	if (!token) {

--- a/src/popup/main.tsx
+++ b/src/popup/main.tsx
@@ -3,7 +3,7 @@
 import { PersistQueryClientProvider } from '@tanstack/react-query-persist-client';
 import React from 'react';
 import { createRoot } from 'react-dom/client';
-import { postEvent } from '../gkApi';
+import { checkin, postEvent } from '../gkApi';
 import { Popup } from './components/Popup';
 import { asyncStoragePersister, queryClient } from './queryClient';
 
@@ -17,6 +17,7 @@ function main() {
 	);
 
 	void postEvent('browserExtensionPopupOpened');
+	void checkin();
 }
 
 main();


### PR DESCRIPTION
I know this PR conflicts with the event PR but it's a one line conflict, I'd rather avoid starting a PR train.

The route isn't live yet, I'll just hold off on merging this until after it is.