### PR TITLE
Make provider dropdown clickable area the full size of the visible UI element

### DIFF
--- a/src/popup/components/FocusView.tsx
+++ b/src/popup/components/FocusView.tsx
@@ -210,10 +210,12 @@ export const FocusView = ({ userId }: { userId: string }) => {
 				</div>
 			)}
 			{selectedProvider && connectedProviders && connectedProviders.length > 1 && (
-				<div className="provider-select text-secondary">
-					PRs: <img src={ProviderMeta[selectedProvider].iconSrc} height={14} />
+				<div className="provider-select-container">
+					<div className="provider-select-prefix text-secondary">
+						PRs: <img src={ProviderMeta[selectedProvider].iconSrc} height={14} />
+					</div>
 					<select
-						className="text-secondary"
+						className="provider-select text-secondary"
 						value={selectedProvider}
 						onChange={onProviderChange}
 						disabled={focusViewDataQuery.isLoading}

--- a/static/popup.css
+++ b/static/popup.css
@@ -203,22 +203,26 @@ html {
 }
 
 /* Focus View - Provider Dropdown */
-.focus-view .provider-select {
-	display: inline-block;
-	border: 1px solid var(--color-border-input);
-	padding: 4px 12px;
-	border-radius: 14px;
-	display: flex;
-	align-items: center;
-	width: fit-content;
+.focus-view .provider-select-container {
+	position: relative;
 	margin-bottom: 12px;
 }
-.focus-view .provider-select img {
+.focus-view .provider-select-prefix {
+	position: absolute;
+	top: 5px;
+	left: 12px;
+	display: flex;
+	align-items: center;
+	pointer-events: none;
+}
+.focus-view .provider-select-prefix img {
 	margin-left: 4px;
 }
-.focus-view .provider-select select {
+.focus-view .provider-select {
 	background: none;
-	border: none;
+	border: 1px solid var(--color-border-input);
+	padding: 4px 0px 4px 60px;
+	border-radius: 14px;
 }
 
 /* Focus View - Pull Request Buckets */


### PR DESCRIPTION
https://gitkraken.atlassian.net/browse/GKCS-5674

`select` elements can't have other tags inside them, only text, so at first I though I'd have to create a custom select implementation to handle the "prefix" (`PRs: [icon]`), or add a dropdown or popover package, but I then thought of a much simpler solution: make the whole thing a `select` but give it margin left so I can show the custom "prefix" content over it.

Before:
<img width="291" alt="image" src="https://github.com/gitkraken/gk-browser-extension/assets/899916/162da4f6-d98f-4d2f-8756-7bd65f5c2ddd">

After:
<img width="279" alt="image" src="https://github.com/gitkraken/gk-browser-extension/assets/899916/1514d888-1835-4d73-a284-92d5b86bc474">

A small side effect is the caret is closer to the edge but that's a result of the caret in native select elements always rendering outside of the select's padding.