### PR TITLE
Update provider apis package

### DIFF
--- a/package.json
+++ b/package.json
@@ -48,7 +48,7 @@
 		"watch:firefox": "yarn run set-manifest:firefox:force && yarn watch"
 	},
 	"dependencies": {
-		"@gitkraken/provider-apis": "0.19.1",
+		"@gitkraken/provider-apis": "0.22.7",
 		"@tanstack/query-async-storage-persister": "5.32.0",
 		"@tanstack/react-query": "5.32.0",
 		"@tanstack/react-query-persist-client": "5.32.0",

--- a/src/popup/components/FocusView.tsx
+++ b/src/popup/components/FocusView.tsx
@@ -1,4 +1,4 @@
-import type { GitPullRequest } from '@gitkraken/provider-apis';
+import type { GitPullRequest, PullRequestBucket, PullRequestWithUniqueID } from '@gitkraken/provider-apis';
 import { GitProviderUtils } from '@gitkraken/provider-apis';
 import { useQueryClient } from '@tanstack/react-query';
 import React, { useEffect, useMemo, useState } from 'react';
@@ -6,18 +6,14 @@ import { storage } from 'webextension-polyfill';
 import { getGitKrakenDeepLinkUrl } from '../../deepLink';
 import { ProviderMeta } from '../../providers';
 import { GKDotDevUrl } from '../../shared';
-import type {
-	FocusViewSupportedProvider,
-	GitPullRequestWithUniqueID,
-	PullRequestBucketWithUniqueIDs,
-} from '../../types';
+import type { FocusViewSupportedProvider } from '../../types';
 import { useFocusViewConnectedProviders, useFocusViewDataQuery, usePullRequestDraftCountsQuery } from '../hooks';
 import { ConnectAProvider } from './ConnectAProvider';
 import { ExternalLink } from './ExternalLink';
 
 type PullRequestRowProps = {
 	userId: string;
-	pullRequest: GitPullRequestWithUniqueID;
+	pullRequest: PullRequestWithUniqueID;
 	provider: FocusViewSupportedProvider;
 	draftCount?: number;
 };
@@ -74,7 +70,7 @@ const PullRequestRow = ({ userId, pullRequest, provider, draftCount = 0 }: PullR
 				<ExternalLink
 					className="pr-drafts-badge text-disabled"
 					href={`${GKDotDevUrl}/drafts/suggested-change/${encodeURIComponent(
-						btoa(pullRequest.uniqueId),
+						btoa(pullRequest.uuid),
 					)}?source=browserExtension`}
 					title={`View code suggestion${draftCount === 1 ? '' : 's'} on gitkraken.dev`}
 				>
@@ -88,7 +84,7 @@ const PullRequestRow = ({ userId, pullRequest, provider, draftCount = 0 }: PullR
 
 type BucketProps = {
 	userId: string;
-	bucket: PullRequestBucketWithUniqueIDs;
+	bucket: PullRequestBucket;
 	provider: FocusViewSupportedProvider;
 	prDraftCountsByEntityID?: Record<string, { count: number } | undefined>;
 };
@@ -106,7 +102,7 @@ const Bucket = ({ userId, bucket, provider, prDraftCountsByEntityID }: BucketPro
 					userId={userId}
 					pullRequest={pullRequest}
 					provider={provider}
-					draftCount={prDraftCountsByEntityID?.[pullRequest.uniqueId]?.count}
+					draftCount={prDraftCountsByEntityID?.[pullRequest.uuid]?.count}
 				/>
 			))}
 		</div>
@@ -238,7 +234,7 @@ export const FocusView = ({ userId }: { userId: string }) => {
 						<Bucket
 							key={bucket.id}
 							userId={userId}
-							bucket={bucket as PullRequestBucketWithUniqueIDs}
+							bucket={bucket}
 							provider={selectedProvider}
 							prDraftCountsByEntityID={prDraftCountsQuery.data}
 						/>

--- a/src/popup/hooks.ts
+++ b/src/popup/hooks.ts
@@ -67,11 +67,11 @@ export const useFocusViewDataQuery = (
 export const usePullRequestDraftCountsQuery = (
 	userId: string,
 	selectedProvider: FocusViewSupportedProvider | null | undefined,
-	pullRequests: { uniqueId: string }[] | undefined,
+	pullRequests: { uuid: string }[] | undefined,
 ) => {
 	let prUniqueIds: string[] = [];
 	if (selectedProvider === 'github' && pullRequests?.length) {
-		prUniqueIds = pullRequests.map(pr => pr.uniqueId);
+		prUniqueIds = pullRequests.map(pr => pr.uuid);
 	}
 
 	return useQuery({

--- a/src/providers.ts
+++ b/src/providers.ts
@@ -1,4 +1,12 @@
-import { AzureDevOps, Bitbucket, GitHub, GitLab } from '@gitkraken/provider-apis';
+import {
+	AzureDevOps,
+	Bitbucket,
+	EntityIdentifierProviderType,
+	EntityIdentifierUtils,
+	EntityType,
+	GitHub,
+	GitLab,
+} from '@gitkraken/provider-apis';
 import { fetchProviderToken } from './gkApi';
 import type { FocusViewData, FocusViewSupportedProvider, Provider, ProviderToken } from './types';
 
@@ -27,13 +35,14 @@ const fetchGitHubFocusViewData = async (token: ProviderToken) => {
 		providerUser: providerUser,
 		pullRequests: pullRequests.map(pr => ({
 			...pr,
-			uuid: JSON.stringify([
-				token.domain ? 'githubEnterprise' : 'github',
-				'pr',
-				'1',
-				token.domain || '',
-				pr.graphQLId || pr.id,
-			]),
+			uuid: EntityIdentifierUtils.encode({
+				provider: token.domain
+					? EntityIdentifierProviderType.GithubEnterprise
+					: EntityIdentifierProviderType.Github,
+				entityType: EntityType.PullRequest,
+				domain: token.domain,
+				entityId: pr.graphQLId || pr.id,
+			}),
 		})),
 	};
 };

--- a/src/providers.ts
+++ b/src/providers.ts
@@ -27,7 +27,7 @@ const fetchGitHubFocusViewData = async (token: ProviderToken) => {
 		providerUser: providerUser,
 		pullRequests: pullRequests.map(pr => ({
 			...pr,
-			uniqueId: JSON.stringify([
+			uuid: JSON.stringify([
 				token.domain ? 'githubEnterprise' : 'github',
 				'pr',
 				'1',
@@ -50,7 +50,7 @@ const fetchGitLabFocusViewData = async (token: ProviderToken) => {
 		username: providerUser.username,
 	});
 
-	return { providerUser: providerUser, pullRequests: pullRequests.map(pr => ({ ...pr, uniqueId: '' })) };
+	return { providerUser: providerUser, pullRequests: pullRequests.map(pr => ({ ...pr, uuid: '' })) };
 };
 
 const fetchBitbucketFocusViewData = async (token: ProviderToken) => {
@@ -62,7 +62,7 @@ const fetchBitbucketFocusViewData = async (token: ProviderToken) => {
 		userId: providerUser.id,
 	});
 
-	return { providerUser: providerUser, pullRequests: pullRequests.map(pr => ({ ...pr, uniqueId: '' })) };
+	return { providerUser: providerUser, pullRequests: pullRequests.map(pr => ({ ...pr, uuid: '' })) };
 };
 
 const fetchAzureFocusViewData = async (token: ProviderToken) => {
@@ -82,7 +82,7 @@ const fetchAzureFocusViewData = async (token: ProviderToken) => {
 		projects: projects.map(project => ({ ...project, project: project.name })),
 	});
 
-	return { providerUser: providerUser, pullRequests: pullRequests.map(pr => ({ ...pr, uniqueId: '' })) };
+	return { providerUser: providerUser, pullRequests: pullRequests.map(pr => ({ ...pr, uuid: '' })) };
 };
 
 export const fetchFocusViewData = async (provider: FocusViewSupportedProvider): Promise<FocusViewData | null> => {

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,4 +1,4 @@
-import type { Account, GitPullRequest, PullRequestBucket } from '@gitkraken/provider-apis';
+import type { Account, PullRequestWithUniqueID } from '@gitkraken/provider-apis';
 
 export interface User {
 	id: string;
@@ -31,17 +31,11 @@ export type FocusViewSupportedProvider =
 	| 'bitbucket'
 	| 'azure';
 
-export type GitPullRequestWithUniqueID = GitPullRequest & { uniqueId: string };
-
-export type PullRequestBucketWithUniqueIDs = Omit<PullRequestBucket, 'pullRequests'> & {
-	pullRequests: GitPullRequestWithUniqueID[];
-};
-
 export type PullRequestDraftCounts = Record<string, { count: number } | undefined>;
 
 export type FocusViewData = {
 	providerUser: Account;
-	pullRequests: GitPullRequestWithUniqueID[];
+	pullRequests: PullRequestWithUniqueID[];
 };
 
 export interface ProviderConnection {

--- a/yarn.lock
+++ b/yarn.lock
@@ -285,10 +285,10 @@
   resolved "https://registry.yarnpkg.com/@eslint/js/-/js-8.44.0.tgz#961a5903c74139390478bdc808bcde3fc45ab7af"
   integrity sha512-Ag+9YM4ocKQx9AarydN0KY2j0ErMHNIocPDrVo8zAE44xLTjEtz81OdR68/cydGtk6m6jDb5Za3r2useMzYmSw==
 
-"@gitkraken/provider-apis@0.19.1":
-  version "0.19.1"
-  resolved "https://registry.npmjs.org/@gitkraken/provider-apis/-/provider-apis-0.19.1.tgz#221556650aa3a0ff6f6841bbd603ca9641c1bce7"
-  integrity sha512-itXor6oELNOe3szzyBhKymS7KuBoDZQMZQh0Ohyp5fnv6W97nOqCmumtOmCYjRH509MMBLp6YBUT+tzRShItKw==
+"@gitkraken/provider-apis@0.22.7":
+  version "0.22.7"
+  resolved "https://registry.npmjs.org/@gitkraken/provider-apis/-/provider-apis-0.22.7.tgz#f217e1d275b578c33a38ce03564a10ee6b6b3e2c"
+  integrity sha512-twLjzIahStD4FkI10UxxikLLocE0r9IkX2qPjZiBfhyZbGKVdnFEdYdbZaeKOxTt87T6LyTPhdGnRLMrZfCWpA==
   dependencies:
     js-base64 "3.7.5"
     node-fetch "2.7.0"


### PR DESCRIPTION
https://gitkraken.atlassian.net/browse/GKCS-5717

Main reason is for bug fixes, specifically the one that prevents PRs from archived repos from appearing in the Launchpad.

There were some minor breaking changes, the `groupPullRequestsIntoBuckets` function now requires that PRs have a `uuid` (the now "official" name for the field that I was calling `uniqueId` before), and the package provides types that include the new field. The package also provides an `encode` function for generating the `uuid` field (it will generate the same string it was generating before so there is no functional change there).