### PR TITLE
Show an error message when Launchpad fails to load data

### DIFF
--- a/src/providers.ts
+++ b/src/providers.ts
@@ -133,20 +133,27 @@ export const fetchFocusViewData = async (provider: FocusViewSupportedProvider): 
 		return null;
 	}
 
-	switch (provider) {
-		case 'github':
-		case 'githubEnterprise':
-			return fetchGitHubFocusViewData(providerToken);
-		case 'gitlab':
-		case 'gitlabSelfHosted':
-			return fetchGitLabFocusViewData(providerToken);
-		case 'bitbucket':
-			return fetchBitbucketFocusViewData(providerToken);
-		case 'bitbucketServer':
-			return fetchBitbucketServerFocusViewData(providerToken);
-		case 'azure':
-			return fetchAzureFocusViewData(providerToken);
-		default:
-			throw new Error(`Attempted to fetch pull requests for unsupported provider: ${provider as Provider}`);
+	try {
+		switch (provider) {
+			case 'github':
+			case 'githubEnterprise':
+				return await fetchGitHubFocusViewData(providerToken);
+			case 'gitlab':
+			case 'gitlabSelfHosted':
+				return await fetchGitLabFocusViewData(providerToken);
+			case 'bitbucket':
+				return await fetchBitbucketFocusViewData(providerToken);
+			case 'bitbucketServer':
+				return await fetchBitbucketServerFocusViewData(providerToken);
+			case 'azure':
+				return await fetchAzureFocusViewData(providerToken);
+			default:
+				throw new Error(`Attempted to fetch pull requests for unsupported provider: ${provider as Provider}`);
+		}
+	} catch (e) {
+		if (e) {
+			Object.assign(e, { provider: provider, domain: providerToken.domain });
+		}
+		throw e;
 	}
 };

--- a/src/types.ts
+++ b/src/types.ts
@@ -40,6 +40,11 @@ export type FocusViewData = {
 	pullRequests: PullRequestWithUniqueID[];
 };
 
+export type FocusViewDataError = Error & {
+	provider?: Provider;
+	domain?: string;
+};
+
 export interface ProviderConnection {
 	provider: Provider;
 	type: string;

--- a/static/popup.css
+++ b/static/popup.css
@@ -269,6 +269,16 @@ html {
 	margin-right: 4px;
 }
 
+/* Focus View - Error */
+.focus-view .focus-view-error {
+	display: flex;
+	flex-direction: column;
+}
+.focus-view .focus-view-error .manage-integrations {
+	text-align: center;
+	margin-top: 8px;
+}
+
 /* Generic components */
 button.icon-btn {
 	background: none;


### PR DESCRIPTION
https://gitkraken.atlassian.net/browse/GKCS-5849

There was no design for this so I just made one up. Let me know if you have any design suggestions.

Cloud-hosted:
<img width="614" alt="image" src="https://github.com/gitkraken/gk-browser-extension/assets/899916/126806ff-456b-4c56-be57-4c5ed7ad4b5a">

Self-hosted:
<img width="610" alt="image" src="https://github.com/gitkraken/gk-browser-extension/assets/899916/4ba172be-359a-42fc-a071-4510eab7030b">

Testing Notes:
You may want to add `retry: 0` to the queryClient default options since by default react-query retries 3 times with exponential backoff, so it can take a while for the error message to show up.