### PR TITLE
[GKDEV-1938] Fix Bitbucket selector to append actions in pull requests

### DIFF
--- a/src/hosts/bitbucket.ts
+++ b/src/hosts/bitbucket.ts
@@ -64,23 +64,26 @@ export function injectionScope(url: string, gkDotDevUrl: string) {
 					}
 					case 'pull-requests': {
 						const compareUrl = this.transformUrl('compare', pathname);
-						insertions.set('.css-1oy5iav', {
-							html: /*html*/ `<a data-gk class="gk-insert-pr css-w97uih" href="${openUrl}" target="_blank" title="${label}" role="menuitem" aria-label="${label}">${this.getGitKrakenSvg(
-								20,
-								undefined,
-								'position:relative; top:4px; left:-5px;',
-							)}Open with GitKraken</a>
+						insertions.set(
+							'[data-qa="page-header-wrapper"] [role="group"], .prCssVarContainer [role="group"]',
+							{
+								html: /*html*/ `<a data-gk class="gk-insert-pr css-w97uih" href="${openUrl}" target="_blank" title="${label}" role="menuitem" aria-label="${label}">${this.getGitKrakenSvg(
+									20,
+									undefined,
+									'position:relative; top:4px; left:-5px;',
+								)}Open with GitKraken</a>
 							<a data-gk class="gk-insert-comparison css-w97uih" href="${compareUrl}" target="_blank" title="${label}" role="menuitem" aria-label="${label}">${this.getGitKrakenSvg(
 								20,
 								undefined,
 								'position:relative; top:4px; left:-5px;',
 							)}Open Comparison with GitKraken</a>`,
-							position: 'afterbegin',
-							replaceSelectorList: [
-								{ selector: '.gk-insert-pr', href: openUrl },
-								{ selector: '.gk-insert-comparison', href: compareUrl },
-							],
-						});
+								position: 'afterbegin',
+								replaceSelectorList: [
+									{ selector: '.gk-insert-pr', href: openUrl },
+									{ selector: '.gk-insert-comparison', href: compareUrl },
+								],
+							},
+						);
 						break;
 					}
 					case 'branches': {


### PR DESCRIPTION
The "Open with GitKraken" and "Open comparison with GitKraken" links should not appear in the "Pull requests" page when there are no items.

Example link: `https://bitbucket.org/<project-name>/workspace/pull-requests/`

![image](https://github.com/user-attachments/assets/0f5248dd-cf42-41d1-8fdf-3ae0ad78605f)

This PR addresses the issue by refining the target selectors, since `.css-1oy5iav` is too generic.

![image](https://github.com/user-attachments/assets/7f5b477e-98a1-4fe8-8c9f-95a620987ab0)

